### PR TITLE
Correctly store aux states

### DIFF
--- a/atem.py
+++ b/atem.py
@@ -344,7 +344,7 @@ class Atem:
 
     def recvAuxS(self, data):
         auxIndex = data[0]
-        self.state[auxIndex] = struct.unpack('!H', data[2:4])[0]
+        self.state['aux'][auxIndex] = struct.unpack('!H', data[2:4])[0]
 
     def recvCCdo(self, data):
         input_num = data[1]


### PR DESCRIPTION
Hi,

I'm writing support for the ATEM series into my own software, using this library as a base - spotted this bug and thought I should pass the fix upstream.

We should record aux states under the `aux` key of `self.state`, not `self.state` itself.